### PR TITLE
Test sequence reordering

### DIFF
--- a/scripts/misc/test.js
+++ b/scripts/misc/test.js
@@ -5,9 +5,12 @@
 var path = require('path'),
 
 	rootPath = path.join(__dirname, '..', '..'),
+	istanbulPath = path.join(rootPath, 'node_modules', 'istanbul'),
 
-	unitTestScript = path.join(rootPath, 'scripts', 'test', 'unit.js'),
-	istanbul = require(path.join(rootPath, 'node_modules', 'istanbul', 'lib', 'cli'));
+	command = require(path.join(istanbulPath, 'lib', 'command')),
+	unitTestScript = path.join(rootPath, 'scripts', 'test', 'unit.js');
+
+require(path.join(istanbulPath, 'lib', 'register-plugins'));
 
 /**
  * Runs unit tests for the app.
@@ -15,10 +18,7 @@ var path = require('path'),
  * @param {Function} done - The callback that marks the end of the unit tests.
  */
 module.exports = function (done) {
-	istanbul.runToCompletion(['cover', '--colors', unitTestScript, '--print', 'both'], function (err, res) {
-		console.info(err, res);
-		done();
-	});
+	command.create('cover').run([unitTestScript, '--print', 'both', '--colors'], done);
 };
 
 !module.parent && module.exports(process.exit); // Directly call the exported function if used via the CLI.

--- a/scripts/test/index.js
+++ b/scripts/test/index.js
@@ -23,7 +23,7 @@ var path = require('path'),
  */
 module.exports = function (done) {
 	console.info(chalk.yellow.bold(figlet.textSync(name))); // eslint-disable-line no-sync
-	async.series([esLint, structure, e2e, security, unit], done);
+	async.series([esLint, structure, security, unit, e2e], done);
 };
 
 !module.parent && module.exports(process.exit); // Directly call the exported function if used via the CLI.


### PR DESCRIPTION
Fixes #246 

* Re-calibrated unit test runner to use callbacks correctly.
* Re-ordered `unit` tests to run before `e2e` tests.