### PR TITLE
Disabled markdown line length checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,6 +14,9 @@ engines:
     enabled: true
   markdownlint:
     enabled: true
+    checks:
+      MD013:
+        enabled: false
 ratings:
   paths:
   - "**.css"

--- a/test/structure/codeclimate-yml.test.js
+++ b/test/structure/codeclimate-yml.test.js
@@ -28,6 +28,7 @@ describe(CODECLIMATE_PATH, function () {
 
 	it('should have the MarkdownLint engine enabled', function () {
 		assert(codeClimateYAML.engines.markdownlint.enabled, 'MarkdownLint config missing / broken');
+		assert(!codeClimateYAML.engines.markdownlint.checks.MD013.enabled, 'MarkdownLint must skip line length');
 	});
 
 	it('should have a valid ratings structure', function () {


### PR DESCRIPTION
Markdown line length checks are no longer enforced during CodeClimate builds.