### PR TITLE
Sans md lint list prefix

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -17,6 +17,8 @@ engines:
     checks:
       MD013:
         enabled: false
+      MD029:
+        enabled: false
 ratings:
   paths:
   - "**.css"

--- a/test/structure/codeclimate-yml.test.js
+++ b/test/structure/codeclimate-yml.test.js
@@ -29,6 +29,7 @@ describe(CODECLIMATE_PATH, function () {
 	it('should have the MarkdownLint engine enabled', function () {
 		assert(codeClimateYAML.engines.markdownlint.enabled, 'MarkdownLint config missing / broken');
 		assert(!codeClimateYAML.engines.markdownlint.checks.MD013.enabled, 'MarkdownLint must skip line length');
+		assert(!codeClimateYAML.engines.markdownlint.checks.MD029.enabled, 'MarkdownLint must skip list prefix');
 	});
 
 	it('should have a valid ratings structure', function () {


### PR DESCRIPTION
This pull request removes the enforcement for ordered list item prefixes in markdown files.