### PR TITLE
Improved purge script

### DIFF
--- a/test/unit/scripts/database.test.js
+++ b/test/unit/scripts/database.test.js
@@ -1,0 +1,14 @@
+var load = require('require-all'),
+
+	database = load(path.resolve('./scripts/database'));
+
+describe('Database scripts', function () {
+	describe('purge', function () {
+		it('should purge the database correctly', function (done) {
+			database.purge(function (err) {
+				assert.strictEqual(err, null, `Purge script failure: ${err}`);
+				done();
+			});
+		});
+	});
+});


### PR DESCRIPTION
* The script can now handle the global `db` instance if present.
* A fallback to `process.env.MONGO_URI` (either pre-existing or from .env)
* A simple starter unit test for the purge script has also been added. (To be expanded with time)