### PR TITLE
Smarter code coverage tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,7 @@ cache:
     - node_modules
 
 after_script:
-  - npm install codeclimate-test-reporter
-  - node node_modules/.bin/codeclimate-test-reporter < .coverage/lcov.info
+  if [[ $TRAVIS_NODE_VERSION=~'^v?8(\.\d+){2}?$' ]]; then
+    npm install codeclimate-test-reporter;
+    node node_modules/.bin/codeclimate-test-reporter < .coverage/lcov.info;
+  fi

--- a/test/structure/travis-yml.test.js
+++ b/test/structure/travis-yml.test.js
@@ -51,8 +51,10 @@ describe(TRAVIS_PATH, function () {
 
 	it('should correctly publish code coverge to CodeClimate', function () {
 		assert.deepStrictEqual(travisYAML.after_script, [
-			'npm install codeclimate-test-reporter',
-			'node node_modules/.bin/codeclimate-test-reporter < .coverage/lcov.info'
-		], 'Invalid post build sequence');
+			'if [[ $TRAVIS_NODE_VERSION=~\'^v?8(\\.\\d+){2}?$\' ]]; then',
+			'npm install codeclimate-test-reporter;',
+			'node node_modules/.bin/codeclimate-test-reporter < .coverage/lcov.info;',
+			'fi'
+		].join(' '), 'Invalid post build sequence');
 	});
 });

--- a/test/unit/bootstrap.test.js
+++ b/test/unit/bootstrap.test.js
@@ -12,9 +12,10 @@ before(function (done) {
 });
 
 after(function (done) {
+	delete process.env.NODE_ENV;
+	delete global.db;
+
 	global.db && db.close ? db.close(function (err) {
-		delete process.env.NODE_ENV;
-		delete global.db;
 		done(err);
 	}) : done();
 });


### PR DESCRIPTION
With this pull request:

* Test coverage is published for one Node version only.
* Also, any injected globals are reliably cleaned up on teardown.